### PR TITLE
Resolves issue #4 (API for measurements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ With your server running, go to the admin site and add a License with the follow
 * version: 2
 
 With that added, you can run a script to load the initial data sets, eg:
+
     python scripts/load_gqahi_nutrients.py data/GQAHI_Nutrients/nitrate\ GQA\ grades\ 2009\ \(Wales\).csv --nutrient N
 
 and likewise for the three other CSV files in the data directory.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,24 @@ If you want to help out:
 * `./manage.py migrate`
 * Add/fix/commit stuff on a branch
 * Submit a pull request
+
+Load initial data
+-----------------
+
+With your server running, go to the admin site and add a License with the following information:
+* name: OGL
+* URL: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/
+* version: 2
+
+With that added, you can run a script to load the initial data sets, eg:
+    python scripts/load_gqahi_nutrients.py data/GQAHI_Nutrients/nitrate\ GQA\ grades\ 2009\ \(Wales\).csv --nutrient N
+
+and likewise for the three other CSV files in the data directory.
+
+Browse the API
+--------------
+After loading some data, you should be able to browse the API at, e.g.:
+
+http://localhost:8000/api/v1/observations/measurements/
+
+See `openwater/urls.py` and `observations/api/urls.py` for more information.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Browse the API
 --------------
 After loading some data, you should be able to browse the API at, e.g.:
 
-http://localhost:8000/api/v1/observations/measurements/
+http://127.0.0.1:8000/api/v1/observations/measurements/
 
 See `openwater/urls.py` and `observations/api/urls.py` for more information.

--- a/observations/api/serializers.py
+++ b/observations/api/serializers.py
@@ -1,6 +1,7 @@
 import json
 
 from rest_framework import serializers
+from rest_framework_gis import serializers as geo_serializers
 
 from observations.models import Measurement
 
@@ -15,7 +16,7 @@ class DictionaryField(serializers.Field):
         return ret
 
 
-class MeasurementSerializer(serializers.ModelSerializer):
+class MeasurementSerializer(geo_serializers.GeoModelSerializer):
     observations = DictionaryField()
 
     class Meta:

--- a/observations/api/serializers.py
+++ b/observations/api/serializers.py
@@ -1,0 +1,26 @@
+import json
+
+from rest_framework import serializers
+
+from observations.models import Measurement
+
+
+class DictionaryField(serializers.Field):
+    def to_native(self, obj):
+        # HStore doesn't allow nested dictionaries, so we parse the escaped
+        # string values to JSON (assuming that's what they in fact are.
+        ret = {
+            k: json.loads(v) for k, v in obj.items()
+        }
+        return ret
+
+
+class MeasurementSerializer(serializers.ModelSerializer):
+    observations = DictionaryField()
+
+    class Meta:
+        model = Measurement
+        fields = (
+            'created_timestamp', 'reference_timestamp', 'location',
+            'location_reference', 'observations', 'source',
+        )

--- a/observations/api/urls.py
+++ b/observations/api/urls.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url
+from django.conf.urls import patterns
+
+from rest_framework.urlpatterns import format_suffix_patterns
+
+from observations.api.views import MeasurementList
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^measurements/$', MeasurementList.as_view()),
+)
+
+urlpatterns = format_suffix_patterns(urlpatterns)

--- a/observations/api/views.py
+++ b/observations/api/views.py
@@ -1,0 +1,9 @@
+from rest_framework import generics
+
+from observations.models import Measurement
+from observations.api.serializers import MeasurementSerializer
+
+
+class MeasurementList(generics.ListAPIView):
+    serializer_class = MeasurementSerializer
+    queryset = Measurement.objects.all()

--- a/openwater/settings.py
+++ b/openwater/settings.py
@@ -147,6 +147,7 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
     'south',
     'django_hstore',
+    'rest_framework',
 
     'supplements',
     'observations',
@@ -179,6 +180,11 @@ LOGGING = {
             'propagate': True,
         },
     }
+}
+
+REST_FRAMEWORK = {
+    'PAGINATE_BY': 10,
+    'PAGINATE_BY_PARAM': 'page_size' 
 }
 
 try:

--- a/openwater/urls.py
+++ b/openwater/urls.py
@@ -17,6 +17,9 @@ urlpatterns = patterns(
     url(r'^supporting-data/', include('supplements.urls')),
     url(r'^observations/', include('observations.urls')),
 
+    url(r'^api/v1/auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^api/v1/observations/', include('observations.api.urls')),
+
     # Uncomment the admin/doc line below to enable admin documentation:
     # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psutil==1.0.1
 psycopg2==2.5.1
 wsgiref==0.1.2
 osgb==0.2dev
+djangorestframework==2.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2==2.5.1
 wsgiref==0.1.2
 osgb==0.2dev
 djangorestframework==2.3.7
+-e git+https://github.com/dmeehan/django-rest-framework-gis.git@9ade355885f3cff07557749a5cf8ea5df90c9280#egg=django-rest-framework-gis


### PR DESCRIPTION
There's an assumption in the serializer for measurements that
observations are nested dictionaries, with values as escaped string
representations of JSON objects.
