### PR TITLE
Map filtering

### DIFF
--- a/observations/api/urls.py
+++ b/observations/api/urls.py
@@ -8,7 +8,8 @@ from observations.api.views import MeasurementList
 
 urlpatterns = patterns(
     '',
-    url(r'^measurements/$', MeasurementList.as_view()),
+    url(r'^measurements/$', MeasurementList.as_view(),
+        name="observations_api_measurements"),
 )
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/observations/api/views.py
+++ b/observations/api/views.py
@@ -1,29 +1,16 @@
-import django_filters
 from rest_framework import generics
 
+from observations.filters import MeasurementFilter
 from observations.models import Measurement
 from observations.api.serializers import (
     CompactMeasurementSerializer, MeasurementSerializer,
 )
 
 
-class MeasurementFilter(django_filters.FilterSet):
-    from_date = django_filters.DateFilter(
-        name='reference_timestamp', lookup_type='gte',
-    )
-    to_date = django_filters.DateFilter(
-        name='reference_timestamp', lookup_type='lte',
-    )
-
-    class Meta:
-        model = Measurement
-        fields = ['from_date', 'to_date']
-
-
 class MeasurementList(generics.ListAPIView):
     serializer_class = MeasurementSerializer
     filter_class = MeasurementFilter
-    queryset = Measurement.objects.all()
+    queryset = Measurement.observations_manager.all()
 
     def get_serializer_class(self):
         if self.request.is_ajax() or self.request.QUERY_PARAMS.get('compact'):

--- a/observations/filters.py
+++ b/observations/filters.py
@@ -1,0 +1,18 @@
+import django_filters
+
+from .models import Measurement
+
+class MeasurementFilter(django_filters.FilterSet):
+    from_date = django_filters.DateFilter(
+        name='reference_timestamp', lookup_type='gte',
+    )
+    to_date = django_filters.DateFilter(
+        name='reference_timestamp', lookup_type='lte',
+    )
+    observed = django_filters.CharFilter(
+        name='observations', lookup_type='contains',
+    )
+
+    class Meta:
+        model = Measurement
+        fields = ['from_date', 'to_date', 'observed']

--- a/observations/templates/map.html
+++ b/observations/templates/map.html
@@ -40,13 +40,13 @@
 {% endblock %}
 {% block js %}
 <script type="text/javascript">
+    var API_ROOT = '{% url "observations_api_measurements" %}';
+
     $(document).ready(function() {
         var map = L.map('map-canvas').setView([55, -4], 6);
         var markers = new L.MarkerClusterGroup({
             disableClusteringAtZoom: 12
         });
-
-        var API_ROOT = '/api/v1/observations/measurements/';
 
         L.tileLayer(
             'http://{s}.tile.cloudmade.com/{{ API_KEY }}/997/256/{z}/{x}/{y}.png',

--- a/observations/templates/map.html
+++ b/observations/templates/map.html
@@ -30,7 +30,7 @@
         <form id="map-filter">
             <p>
                 <label for="page_size">Max results:</label>
-                <input type="text" name="page_size" value="5000" />
+                <input type="text" id="id_page_size" name="page_size" value="5000" />
             </p>
             {{ filter.form.as_p }}
             <input type="submit" />
@@ -69,7 +69,6 @@
                 var from = $('#id_from_date').val();
                 var to = $('#id_to_date').val();
                 var limit = $('#id_page_size').val();
-                var count = data.results.length;
 
                 if (observed) {
                     msg += ' of ' + observed;
@@ -83,8 +82,8 @@
                     msg += ' up to ' + to;
                 }
 
-                if (limit !== count) {
-                    msg += ' (showing most recent ' + count + ')';
+                if (limit < data.count) {
+                    msg += ' (showing most recent ' + data.results.length + ')';
                 }
 
                 $('#meta').html(msg);

--- a/observations/templates/map.html
+++ b/observations/templates/map.html
@@ -75,7 +75,11 @@
                 }
 
                 if (from && to) {
-                    msg += ' between ' + from + ' and ' + to;
+                    if (from === to) {
+                        msg += ' on ' + from;
+                    } else {
+                        msg += ' between ' + from + ' and ' + to;
+                    }
                 } else if (from) {
                     msg += ' since ' + from;
                 } else if (to) {
@@ -83,10 +87,10 @@
                 }
 
                 if (limit < data.count) {
-                    msg += ' (showing most recent ' + data.results.length + ')';
+                    msg += ' (showing the most recent ' + data.results.length + ')';
                 }
 
-                $('#meta').html(msg);
+                $('#meta').html(msg + '.');
             });
         };
 

--- a/observations/templates/map.html
+++ b/observations/templates/map.html
@@ -27,33 +27,76 @@
 {% block content %}
     <div class="span12">
         <div id="map-canvas"></div>
+        <form id="map-filter">
+            <p>
+                <label for="page_size">Max results:</label>
+                <input type="text" name="page_size" value="5000" />
+            </p>
+            {{ filter.form.as_p }}
+            <input type="submit" />
+        </form>
+        <span id="meta"></span>
     </div>
 {% endblock %}
 {% block js %}
 <script type="text/javascript">
-    var map = L.map('map-canvas').setView([55, -4], 6);
-    var markers = new L.MarkerClusterGroup({
-        disableClusteringAtZoom: 12
-    });
-    L.tileLayer(
-        'http://{s}.tile.cloudmade.com/{{ API_KEY }}/997/256/{z}/{x}/{y}.png',
-        {
-            attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://cloudmade.com">CloudMade</a>',
-            maxZoom: 18
-        }
-    ).addTo(map);
-
-    $.getJSON('/api/v1/observations/measurements/?page_size=5000&from_date=2008-01-01', function(data) {
-        var geoJsonLayer = L.geoJson(data.results, {
-            style: function(feature) {
-                return {};
-            },
-            onEachFeature: function(feature, layer) {
-                //
-            }
+    $(document).ready(function() {
+        var map = L.map('map-canvas').setView([55, -4], 6);
+        var markers = new L.MarkerClusterGroup({
+            disableClusteringAtZoom: 12
         });
-        markers.addLayer(geoJsonLayer);
-        map.addLayer(markers);
+
+        var API_ROOT = '/api/v1/observations/measurements/';
+
+        L.tileLayer(
+            'http://{s}.tile.cloudmade.com/{{ API_KEY }}/997/256/{z}/{x}/{y}.png',
+            {
+                attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://cloudmade.com">CloudMade</a>',
+                maxZoom: 18
+            }
+        ).addTo(map);
+
+        var updateMap = function() {
+            $('#meta').html('Loading...');
+            markers.clearLayers();
+            $.getJSON(API_ROOT + '?' + $('#map-filter').serialize(), function(data) {
+                var geoJsonLayer = L.geoJson(data.results);
+                markers.addLayer(geoJsonLayer);
+                map.addLayer(markers);
+
+                var msg = data.count + ' observations';
+                var observed = $('#id_observed').val();
+                var from = $('#id_from_date').val();
+                var to = $('#id_to_date').val();
+                var limit = $('#id_page_size').val();
+                var count = data.results.length;
+
+                if (observed) {
+                    msg += ' of ' + observed;
+                }
+
+                if (from && to) {
+                    msg += ' between ' + from + ' and ' + to;
+                } else if (from) {
+                    msg += ' since ' + from;
+                } else if (to) {
+                    msg += ' up to ' + to;
+                }
+
+                if (limit !== count) {
+                    msg += ' (showing most recent ' + count + ')';
+                }
+
+                $('#meta').html(msg);
+            });
+        };
+
+        $('#map-filter').submit(function(e) {
+            e.preventDefault();
+            updateMap();
+        });
+
+        updateMap();
     });
 </script>
 {% endblock %}

--- a/observations/views.py
+++ b/observations/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.views.generic.base import TemplateView
 
 from .models import Measurement
+from .filters import MeasurementFilter
 
 
 class MapView(TemplateView):
@@ -10,4 +11,9 @@ class MapView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(MapView, self).get_context_data(**kwargs)
         context.update(API_KEY=settings.CLOUDMADE_API_KEY)
+        f = MeasurementFilter(
+            self.request.GET,
+            queryset=Measurement.observations_manager.all(),
+        )
+        context.update({'filter': f})
         return context


### PR DESCRIPTION
The model filter is now passed into the map page context & renders a form we use
for updating the map. The 'observed' field basically checks the key in
the hstore 'observations' field, so based on the bootstrap data, valid
lookups are 'Nitrates', and 'Orthophosphates'. Dates should be
YYYY-MM-DD, but really we need to hook up some kind of calendar widget
here.

Resolves #14 (at least for now; it needs some UI work, and will have to be updated to account for model changes going on elsewhere).
