### PR TITLE
Filter form tweaks

### DIFF
--- a/observations/filters.py
+++ b/observations/filters.py
@@ -19,6 +19,7 @@ class MeasurementFilter(django_filters.FilterSet):
                 'todayBtn': 'true',
                 'todayHighlight': 'true',
                 'minView': 2,
+                'startView': 3,
             })
     )
     to_date = django_filters.DateTimeFilter(
@@ -33,13 +34,10 @@ class MeasurementFilter(django_filters.FilterSet):
                 'todayBtn': 'true',
                 'todayHighlight': 'true',
                 'minView': 2,
+                'startView': 3,
             })
-    )
-    parameter = django_filters.ChoiceFilter(
-        name='parameters__parameter__name',
-        choices=[(p.name, p.name) for p in Parameter.objects.all()],
     )
 
     class Meta:
         model = Measurement
-        fields = ['from_date', 'to_date', 'parameter']
+        fields = ['from_date', 'to_date', 'parameters']

--- a/observations/templates/map.html
+++ b/observations/templates/map.html
@@ -35,6 +35,7 @@
             </p>
             {{ filter.form.as_p }}
             <input type="submit" />
+            <input type="reset" />
         </form>
         <span id="meta"></span>
     </div>


### PR DESCRIPTION
- date time picker starts on month view (easier for skipping back a few
  years)
- let django-filter build the form for filtering by parameters
  automatically
- add a reset button (because django-datetime-widget doesn't let you
  clear the field once you've picked a date
